### PR TITLE
 Fix Character Encoding Issue - Displaying Symbols Correctly

### DIFF
--- a/script.js
+++ b/script.js
@@ -54,12 +54,12 @@ function showQue(i){
     shuffleArray(options);
     let tempq = document.createElement("p");
         tempq.className = "que";
-        tempq.textContent = i+1+". "+currentQuestion.question;
+        tempq.innerHTML = i+1+". "+currentQuestion.question;
         que_cont.prepend(tempq);
     options.forEach(opt => {
         let temp = document.createElement("div");
         temp.className = "opt";
-        temp.textContent = opt;
+        temp.innerHTML = opt;
         opt_cont.appendChild(temp);
         temp.addEventListener("click",()=>{
             i++;


### PR DESCRIPTION
This pull request addresses a character encoding issue that caused certain symbols to display incorrectly on the webpage. Instead of the intended symbols, users were seeing quotation marks ("") and the code "#039s;". This issue was observed in both Chrome and Firefox browsers on Linux and Windows 10 operating systems.

The fix implemented in this PR ensures that the webpage uses the correct character encoding, allowing all symbols to render properly.

This improvement will enhance the user experience by ensuring accurate display of all content on the webpage.
# Screenshot
![Screenshot from 2024-07-10 12-57-45](https://github.com/ritiku2004/Quick-Quize/assets/144889143/2d44d4e7-4574-4369-a89d-5ac452c2d598)
